### PR TITLE
Gunslinger / Ninja class

### DIFF
--- a/npc/custom/jobmaster.txt
+++ b/npc/custom/jobmaster.txt
@@ -416,12 +416,6 @@ function	Get_Job_Equip	{
 				getitem 1907,1;	break;	//	Guitar [0]
 			case Job_Dancer:
 				getitem 1960,1;	break;	//	Whip [1]
-			case Job_Super_Novice:
-				getitem 1208,1;	break;	//	Main Gauche [4]
-			case Job_Gunslinger:
-				getitem 13101,1; break;	//	Six Shooter [2]
-			case Job_Ninja:
-				getitem 13010,1; break;	//	Asura [2]
 			case Job_Star_Gladiator:
 				getitem 1550,1;	break;	//	Book [3]
 			case Job_Soul_Linker:
@@ -444,6 +438,12 @@ function	Get_Job_Equip	{
 				getitem 1302,1;	break;	//	Axe [4]
 			case Job_Thief:
 				getitem 1208,1;	break;	//	Main Gauche [4]
+			case Job_Super_Novice:
+				getitem 1208,1;	break;	//	Main Gauche [4]
+			case Job_Gunslinger:
+				getitem 13101,1; break;	//	Six Shooter [2]
+			case Job_Ninja:
+				getitem 13010,1; break;	//	Asura [2]
 		}
 	}
 	return;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  Gunslinger and Ninja classes are not getting their `.GetJobEquip` upon chaning.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixed and now npc gives out free equipment's for these classes.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
